### PR TITLE
Fix visitorData retrieval for some users

### DIFF
--- a/app/src/main/java/com/zionhuang/music/App.kt
+++ b/app/src/main/java/com/zionhuang/music/App.kt
@@ -65,6 +65,7 @@ class App : Application(), ImageLoaderFactory {
                 .distinctUntilChanged()
                 .collect { visitorData ->
                     YouTube.visitorData = visitorData
+                        ?.takeIf { it != "null" } // Previously visitorData was sometimes saved as "null" due to a bug
                         ?: YouTube.visitorData().getOrNull()?.also { newVisitorData ->
                             dataStore.edit { settings ->
                                 settings[VisitorDataKey] = newVisitorData

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -9,6 +9,7 @@ import com.zionhuang.innertube.pages.*
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import java.net.Proxy
@@ -333,7 +334,7 @@ object YouTube {
         Json.parseToJsonElement(innerTube.getSwJsData().bodyAsText().substring(5))
             .jsonArray[0]
             .jsonArray[2]
-            .jsonArray[6]
+            .jsonArray.first { (it as? JsonPrimitive)?.content?.startsWith(VISITOR_DATA_PREFIX) == true }
             .jsonPrimitive.content
     }
 
@@ -354,6 +355,8 @@ object YouTube {
     }
 
     private const val MAX_GET_QUEUE_SIZE = 1000
+
+    private const val VISITOR_DATA_PREFIX = "Cgt"
 
     const val DEFAULT_VISITOR_DATA = "CgtsZG1ySnZiQWtSbyiMjuGSBg%3D%3D"
 }


### PR DESCRIPTION
For some users (or at least for me in Spain) the json returned by https://music.youtube.com/sw.js_data is sightly different and the visitorData string is returned at a different index in the inner array, so the method visitorData() in YouTube.kt fails to obtain it and instead returns the string "null", causing some problems like the artist albums page and the recommendations to stop working.

I've improved the parsing code so that it searches in the array for a string that starts with the correct visitor data prefix instead of returning the one at a fixed index, solving these problems.

Fixes #568 and probably #605 