### PR TITLE
Fix search continuation

### DIFF
--- a/innertube/src/main/java/com/zionhuang/innertube/models/response/SearchResponse.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/response/SearchResponse.kt
@@ -12,7 +12,7 @@ data class SearchResponse(
 ) {
     @Serializable
     data class Contents(
-        val tabbedSearchResultsRenderer: Tabs,
+        val tabbedSearchResultsRenderer: Tabs?,
     )
 
     @Serializable


### PR DESCRIPTION
tabbedSearchResultsRenderer was marked as non-nullable, but it's null in the search continuation response.

Fixes #676 