### PR TITLE
Add "play time" sort mode to all song listings

### DIFF
--- a/app/src/main/java/com/zionhuang/music/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/zionhuang/music/constants/PreferenceKeys.kt
@@ -52,15 +52,15 @@ val ArtistSongSortDescendingKey = booleanPreferencesKey("artistSongSortDescendin
 val PlaylistEditLockKey = booleanPreferencesKey("playlistEditLock")
 
 enum class SongSortType {
-    CREATE_DATE, NAME, ARTIST
+    CREATE_DATE, NAME, ARTIST, PLAY_TIME
 }
 
 enum class DownloadedSongSortType {
-    CREATE_DATE, NAME, ARTIST
+    CREATE_DATE, NAME, ARTIST, PLAY_TIME
 }
 
 enum class PlaylistSongSortType {
-    CUSTOM, CREATE_DATE, NAME, ARTIST
+    CUSTOM, CREATE_DATE, NAME, ARTIST, PLAY_TIME
 }
 
 enum class ArtistSortType {
@@ -68,7 +68,7 @@ enum class ArtistSortType {
 }
 
 enum class ArtistSongSortType {
-    CREATE_DATE, NAME
+    CREATE_DATE, NAME, PLAY_TIME
 }
 
 enum class AlbumSortType {

--- a/app/src/main/java/com/zionhuang/music/db/DatabaseDao.kt
+++ b/app/src/main/java/com/zionhuang/music/db/DatabaseDao.kt
@@ -30,6 +30,10 @@ interface DatabaseDao {
     @Query("SELECT * FROM song WHERE inLibrary IS NOT NULL ORDER BY title")
     fun songsByNameAsc(): Flow<List<Song>>
 
+    @Transaction
+    @Query("SELECT * FROM song WHERE inLibrary IS NOT NULL ORDER BY totalPlayTime")
+    fun songsByPlayTimeAsc(): Flow<List<Song>>
+
     fun songs(sortType: SongSortType, descending: Boolean) =
         when (sortType) {
             SongSortType.CREATE_DATE -> songsByCreateDateAsc()
@@ -39,6 +43,7 @@ interface DatabaseDao {
                     song.artists.joinToString(separator = "") { it.name }
                 }
             }
+            SongSortType.PLAY_TIME -> songsByPlayTimeAsc()
         }.map { it.reversed(descending) }
 
     @Transaction
@@ -53,6 +58,10 @@ interface DatabaseDao {
     @Query("SELECT * FROM song WHERE liked ORDER BY title")
     fun likedSongsByNameAsc(): Flow<List<Song>>
 
+    @Transaction
+    @Query("SELECT * FROM song WHERE liked ORDER BY totalPlayTime")
+    fun likedSongsByPlayTimeAsc(): Flow<List<Song>>
+
     fun likedSongs(sortType: SongSortType, descending: Boolean) =
         when (sortType) {
             SongSortType.CREATE_DATE -> likedSongsByCreateDateAsc()
@@ -62,6 +71,7 @@ interface DatabaseDao {
                     song.artists.joinToString(separator = "") { it.name }
                 }
             }
+            SongSortType.PLAY_TIME -> likedSongsByPlayTimeAsc()
         }.map { it.reversed(descending) }
 
     @Query("SELECT COUNT(1) FROM song WHERE liked")
@@ -83,10 +93,15 @@ interface DatabaseDao {
     @Query("SELECT song.* FROM song_artist_map JOIN song ON song_artist_map.songId = song.id WHERE artistId = :artistId AND inLibrary IS NOT NULL ORDER BY title")
     fun artistSongsByNameAsc(artistId: String): Flow<List<Song>>
 
+    @Transaction
+    @Query("SELECT song.* FROM song_artist_map JOIN song ON song_artist_map.songId = song.id WHERE artistId = :artistId AND inLibrary IS NOT NULL ORDER BY totalPlayTime")
+    fun artistSongsByPlayTimeAsc(artistId: String): Flow<List<Song>>
+
     fun artistSongs(artistId: String, sortType: ArtistSongSortType, descending: Boolean) =
         when (sortType) {
             ArtistSongSortType.CREATE_DATE -> artistSongsByCreateDateAsc(artistId)
             ArtistSongSortType.NAME -> artistSongsByNameAsc(artistId)
+            ArtistSongSortType.PLAY_TIME -> artistSongsByPlayTimeAsc(artistId)
         }.map { it.reversed(descending) }
 
     @Transaction

--- a/app/src/main/java/com/zionhuang/music/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/artist/ArtistSongsScreen.kt
@@ -95,6 +95,7 @@ fun ArtistSongsScreen(
                         when (sortType) {
                             ArtistSongSortType.CREATE_DATE -> R.string.sort_by_create_date
                             ArtistSongSortType.NAME -> R.string.sort_by_name
+                            ArtistSongSortType.PLAY_TIME -> R.string.sort_by_play_time
                         }
                     },
                     trailingText = pluralStringResource(R.plurals.n_song, songs.size, songs.size)

--- a/app/src/main/java/com/zionhuang/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/library/LibrarySongsScreen.kt
@@ -79,6 +79,7 @@ fun LibrarySongsScreen(
                             SongSortType.CREATE_DATE -> R.string.sort_by_create_date
                             SongSortType.NAME -> R.string.sort_by_name
                             SongSortType.ARTIST -> R.string.sort_by_artist
+                            SongSortType.PLAY_TIME -> R.string.sort_by_play_time
                         }
                     },
                     trailingText = pluralStringResource(R.plurals.n_song, songs.size, songs.size)

--- a/app/src/main/java/com/zionhuang/music/ui/screens/playlist/BuiltInPlaylistScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/playlist/BuiltInPlaylistScreen.kt
@@ -114,6 +114,7 @@ fun BuiltInPlaylistScreen(
                                 SongSortType.CREATE_DATE -> R.string.sort_by_create_date
                                 SongSortType.NAME -> R.string.sort_by_name
                                 SongSortType.ARTIST -> R.string.sort_by_artist
+                                SongSortType.PLAY_TIME -> R.string.sort_by_play_time
                             }
                         },
                         trailingText = joinByBullet(
@@ -132,6 +133,7 @@ fun BuiltInPlaylistScreen(
                                 DownloadedSongSortType.CREATE_DATE -> R.string.sort_by_create_date
                                 DownloadedSongSortType.NAME -> R.string.sort_by_name
                                 DownloadedSongSortType.ARTIST -> R.string.sort_by_artist
+                                DownloadedSongSortType.PLAY_TIME -> R.string.sort_by_play_time
                             }
                         },
                         trailingText = joinByBullet(

--- a/app/src/main/java/com/zionhuang/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -443,6 +443,7 @@ fun LocalPlaylistScreen(
                                         PlaylistSongSortType.CREATE_DATE -> R.string.sort_by_create_date
                                         PlaylistSongSortType.NAME -> R.string.sort_by_name
                                         PlaylistSongSortType.ARTIST -> R.string.sort_by_artist
+                                        PlaylistSongSortType.PLAY_TIME -> R.string.sort_by_play_time
                                     }
                                 },
                                 trailingText = "",

--- a/app/src/main/java/com/zionhuang/music/viewmodels/BuiltInPlaylistViewModel.kt
+++ b/app/src/main/java/com/zionhuang/music/viewmodels/BuiltInPlaylistViewModel.kt
@@ -71,6 +71,7 @@ class BuiltInPlaylistViewModel @Inject constructor(
                 DownloadedSongSortType.ARTIST -> songs.sortedBy { song ->
                     song.first.artists.joinToString(separator = "") { it.name }
                 }
+                DownloadedSongSortType.PLAY_TIME -> songs.sortedBy { it.first.song.totalPlayTime }
             }
                 .map { it.first }
                 .reversed(descending)

--- a/app/src/main/java/com/zionhuang/music/viewmodels/LocalPlaylistViewModel.kt
+++ b/app/src/main/java/com/zionhuang/music/viewmodels/LocalPlaylistViewModel.kt
@@ -44,6 +44,7 @@ class LocalPlaylistViewModel @Inject constructor(
             PlaylistSongSortType.ARTIST -> songs.sortedBy { song ->
                 song.song.artists.joinToString { it.name }
             }
+            PlaylistSongSortType.PLAY_TIME -> songs.sortedBy { it.song.song.totalPlayTime }
         }.reversed(sortDescending && sortType != PlaylistSongSortType.CUSTOM)
     }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 }


### PR DESCRIPTION
This commit adds the "play time" sort back to all song listings (library, playlist songs, artist songs).

**Disclaimer: this is my first time contributing to an Android project so you may want to double-check the changes.** My testing so far seems to indicate everything is working fine, and I'll continue to test this version as my main music player.

I also plan to add this sorting mode to the artist and album listings if there's interest for that.

Btw, thanks for the cool project :slightly_smiling_face: 