### PR TITLE
Switch to kavin.rocks because age restricted songs won't play on whatever.social

### DIFF
--- a/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
@@ -141,7 +141,7 @@ class InnerTube {
     }
 
     suspend fun pipedStreams(videoId: String) =
-        httpClient.get("https://watchapi.whatever.social/streams/${videoId}") {
+        httpClient.get("https://pipedapi.kavin.rocks/streams/${videoId}") {
             contentType(ContentType.Application.Json)
         }
 


### PR DESCRIPTION
In the issue I opened about what I assumed to be the audio codec, @javdc mentioned that it's because of the piped instance, so we should reconsider this probably.