### PR TITLE
Add "play time" sorting to artists and albums screens

### DIFF
--- a/app/src/main/java/com/zionhuang/music/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/zionhuang/music/constants/PreferenceKeys.kt
@@ -64,7 +64,7 @@ enum class PlaylistSongSortType {
 }
 
 enum class ArtistSortType {
-    CREATE_DATE, NAME, SONG_COUNT
+    CREATE_DATE, NAME, SONG_COUNT, PLAY_TIME
 }
 
 enum class ArtistSongSortType {
@@ -72,7 +72,7 @@ enum class ArtistSongSortType {
 }
 
 enum class AlbumSortType {
-    CREATE_DATE, NAME, ARTIST, YEAR, SONG_COUNT, LENGTH
+    CREATE_DATE, NAME, ARTIST, YEAR, SONG_COUNT, LENGTH, PLAY_TIME
 }
 
 enum class PlaylistSortType {

--- a/app/src/main/java/com/zionhuang/music/ui/screens/library/LibraryAlbumsScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/library/LibraryAlbumsScreen.kt
@@ -69,6 +69,7 @@ fun LibraryAlbumsScreen(
                             AlbumSortType.YEAR -> R.string.sort_by_year
                             AlbumSortType.SONG_COUNT -> R.string.sort_by_song_count
                             AlbumSortType.LENGTH -> R.string.sort_by_length
+                            AlbumSortType.PLAY_TIME -> R.string.sort_by_play_time
                         }
                     },
                     trailingText = pluralStringResource(R.plurals.n_album, albums.size, albums.size)

--- a/app/src/main/java/com/zionhuang/music/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/library/LibraryArtistsScreen.kt
@@ -55,6 +55,7 @@ fun LibraryArtistsScreen(
                             ArtistSortType.CREATE_DATE -> R.string.sort_by_create_date
                             ArtistSortType.NAME -> R.string.sort_by_name
                             ArtistSortType.SONG_COUNT -> R.string.sort_by_song_count
+                            ArtistSortType.PLAY_TIME -> R.string.sort_by_play_time
                         }
                     },
                     trailingText = pluralStringResource(R.plurals.n_artist, artists.size, artists.size)


### PR DESCRIPTION
Continuation of #793.

As usual please make sure I didn't break anything, but my testing so far seems to be good, and I plan to continue testing this for the foreseeable future.

---

During my testing I noticed the "Albums" section of the "Stats" takes an abnormally long time to load, though I don't know what may be causing this.

---

On an unrelated note, the next thing I'd like to improve is adding individual pages for each type of element in the stats screen, so we can explore more than 6 entries.

Once that is done, I'd suggest adding links to these pages directly from the main tabs of the library in order to improve the navigation and discoverability of content within the app - I can open a discussion if you'd like to discuss this before I start working on it.