### PR TITLE
Fix saved albums not showing saved song icons

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/AlbumScreen.kt
@@ -181,6 +181,7 @@ fun AlbumScreen(
                             albumIndex = index + 1,
                             isActive = song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
+                            showInLibraryIcon = true,
                             trailingContent = {
                                 IconButton(
                                     onClick = {


### PR DESCRIPTION
Fix saved albums not showing icon for saved songs

---

I noticed there's a lot of duplicate code between local and remote albums while exploring the code.

I don't want to touch this as i don't know the broader codebase very well, but I think we could parametrize these to avoid duplication and make the project more maintainable in the long run.